### PR TITLE
Added "103 - Early Hints" status

### DIFF
--- a/json/misc.json
+++ b/json/misc.json
@@ -1,10 +1,18 @@
 //  Miscellanious Status Codes
 //  https://tools.ietf.org/html/draft-tbray-http-legally-restricted-status-00
+//  https://tools.ietf.org/html/draft-kazuho-early-hints-status-code-00
 
 {
+	//  1xx  -  Informational
+	//  This informational status code indicates the client that the server
+    //  is likely to send a final request with the headers included in the
+    //  informational response.
+	"103": "Early Hints",
+
+
 	//  4xx  -  User Error
 
-	//   This status code indicates that the server is subject to legal restrictions which prevent it
+	//  This status code indicates that the server is subject to legal restrictions which prevent it
 	//  servicing the request. Since such restrictions typically apply to all operators in a legal
 	//  jurisdiction, the server in question may or may not be an origin server. The restrictions typically
 	//  most directly affect the operations of ISPs and search engines. Responses using this status code

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,7 @@ var Lab = require('lab'),
 	lab = exports.lab = Lab.script(),
 	Code = require('code'),
 	HTTPStatusCode = require('../lib'),
-	protocols = ['HTTP/1.0', 'HTTP/1.1', 'HTTP/2', 'WEBDAV'],
+	protocols = ['HTTP/1.0', 'HTTP/1.1', 'HTTP/2', 'WEBDAV', 'misc'],
 	definitions = HTTPStatusCode.getProtocolDefinitions();
 
 protocols.forEach(function(protocol) {


### PR DESCRIPTION
json/misc.json
+ Added “103 - Early Hints” status, as proposed in
https://tools.ietf.org/html/draft-kazuho-early-hints-status-code-00

test/index.js
* added tests for “misc”, actually testing every possible status code
(this includes all types in “misc”)